### PR TITLE
Clarify mysite/urls.py location for tutorial-01

### DIFF
--- a/docs/intro/tutorial01.txt
+++ b/docs/intro/tutorial01.txt
@@ -329,6 +329,9 @@ text "*Hello, world. You're at the polls index.*", which you defined in the
 
     If you get an error page here, check that you're going to
     http://localhost:8000/polls/ and not http://localhost:8000/.
+    Also make sure you didn't accidentally create the file ``mysite/urls.py``
+    in the outer ``mysite/`` directory. (``mysite/mysite/urls.py``) You should
+    modify the file in the inner ``mysite/`` directory. ( ``mysite/urls.py``)
 
 The :func:`~django.urls.path` function is passed four arguments, two required:
 ``route`` and ``view``, and two optional: ``kwargs``, and ``name``.


### PR DESCRIPTION
According to [this answer on StackOverflow](https://stackoverflow.com/a/29657129/), 82 people accidentally created the `mysite/urls.py` in the outer `mysite` directory (`mysite/mysite/urls.py`) instead of modifying the inner `mysite` directory (`mysite/urls.py`) when following [tutorial-01](https://docs.djangoproject.com/en/3.1/intro/tutorial01/).

This PR adds a hint to ask readers to double check the file location. This can help future readers who encounters this issue to follow the tutorial more smoothly (instead of searching on Google to see the StackOverflow post)